### PR TITLE
Store both path and url for sqrip files

### DIFF
--- a/sqrip-woocommerce.php
+++ b/sqrip-woocommerce.php
@@ -107,6 +107,11 @@ if (!function_exists('sqrip_add_fields_for_order_details')) {
 
         $reference_id = get_post_meta($post->ID, 'sqrip_reference_id', true);
         $pdf_file = get_post_meta($post->ID, 'sqrip_pdf_file_url', true);
+	    
+        // check for legacy pdf meta file
+        if(!$pdf_file) {
+            $pdf_file = get_post_meta($post->ID, 'sqrip_pdf_file', true);
+        }
         
         if ($reference_id || $pdf_file) {
             echo '<ul class="sqrip-payment">';


### PR DESCRIPTION
E-mail attachments require a path to the file on the web server and not a URL. This commit adds two new post meta fields for both the path and the url.