### PR TITLE
1.10.2: stop the settings screen from switching features on by itself

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://sqrip.ch/
 Tags: woocommerce, payment, swiss qr invoice, qr-rechnung, einzahlungsschein
 Requires at least: 6.0
 Tested up to: 7.0
-Stable tag: 1.10.1
+Stable tag: 1.10.2
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -145,6 +145,11 @@ Yes. We are already working on comparing the reconciliation of orders/purchases 
 7. Refund functionality
 
 == Changelog ==
+= 1.10.2 : Juli 2026 – Fix =
+* Opening the sqrip settings no longer ticks 'Payment Comparison' by itself. On shops with the feature switched off the checkbox appeared ticked as soon as the settings screen was opened, so saving switched the feature on. It affects 1.10 and 1.10.1; if you do not use the payment comparison, check the setting once on the Services tab after updating;
+* Switching 'Payment Comparison' off no longer switches 'Multiple QR-Slips' on, and the other way round. The two still cannot run at the same time — switching one on turns the other off — but you can now leave both off, which was impossible before. Toggling the Refunds checkbox no longer affected the two either;
+* Clarification on the automatic clean-up: the retention period under 'Delete QR invoices after ... days' applies to your existing QR invoices as well, not only to newly created ones. Invoices of orders still waiting for payment are always kept, and order data, amounts and references are never affected;
+
 = 1.10.1 : Juli 2026 – Fixes =
 * New button in the settings: delete all QR-invoice PDFs created up to today right away, instead of waiting for the daily clean-up. Invoices of orders that are still waiting for payment are always kept;
 * The clean-up now also removes files that were previously left behind: refund QR codes, the PNG for the PDF-invoice integration, the individual slips of a multi-invoice order, and leftovers from earlier regenerations;
@@ -344,6 +349,9 @@ We made users (even more) happy with these changes:
 * Here we go!
 
 == Upgrade Notice ==
+= 1.10.2 =
+Recommended update for everyone on 1.10 or 1.10.1: opening the sqrip settings ticked 'Payment Comparison' by itself, so saving switched the feature on. If you do not use it, check that setting once on the Services tab after updating.
+
 = 1.10.1 =
 Recommended update for everyone on 1.10: fixes the clean-up so it can only ever delete sqrip's own files, prevents refunds from being recorded without a refund QR code, stops the order status being reset when the confirmation page is reopened, and restores the 'Generate QR Invoice' button for manually created orders. Also adds a clean-up button, a settable logo height and an informal form of address.
 

--- a/js/sqrip-admin.js
+++ b/js/sqrip-admin.js
@@ -529,33 +529,28 @@ jQuery(document).ready(function ($) {
         })
     });
 
-    toggleComparisonAndMultipleSlips();
-    //Toggle "comparison" and "multiple-qr-slips"
+    // Switching one of the two features ON switches the other OFF — they cannot run at the
+    // same time. Switching one OFF must leave the other alone: a shop is free to use neither.
+    //
+    // The old version did the opposite in its "else" branches and ticked the other checkbox
+    // whenever one was unticked, so a shop could never end up with both off. It also ran on
+    // page load with no argument, which ticked "Payment Comparison" on every shop that had
+    // multiple QR-slips off — saving then switched the feature on and reported the service as
+    // active to the sqrip account, without the merchant ever choosing it. And because the old
+    // "else" caught every other feature too, toggling the Refunds checkbox went through the
+    // multiple-QR-slips branch as well.
+    //
+    // Called only from the change handler above, never on page load.
     function toggleComparisonAndMultipleSlips(feature) {
-        if (feature === 'comparison') {
-            if (ip_payment_comparison_enabled.is(':checked')) {
-                ip_multiple_qr_slips_enabled.prop("checked", false);
-                // ip_multiple_qr_slips_enabled.attr("disabled", true);
-                $('.sqrip-tab[data-tab="multiple-qr-slips"]').hide();
-            } else {
-                // ip_multiple_qr_slips_enabled.attr("disabled", false);
-                ip_multiple_qr_slips_enabled.prop("checked", true);
-                $('.sqrip-tab[data-tab="multiple-qr-slips"]').show();
-            }
-
-        } else {
-
-            if (ip_multiple_qr_slips_enabled.is(':checked')) {
-                ip_payment_comparison_enabled.prop("checked", false);
-                // ip_payment_comparison_enabled.attr("disabled", true);
-                $('.sqrip-tab[data-tab="comparison"]').hide();
-            } else {
-                // ip_payment_comparison_enabled.attr("disabled", false);
-                ip_payment_comparison_enabled.prop("checked", true);
-                $('.sqrip-tab[data-tab="comparison"]').show();
-            }
+        if (feature === 'comparison' && ip_payment_comparison_enabled.is(':checked')) {
+            ip_multiple_qr_slips_enabled.prop("checked", false);
+            $('.sqrip-tab[data-tab="multiple-qr-slips"]').hide();
         }
 
+        if (feature === 'multiple-qr-slips' && ip_multiple_qr_slips_enabled.is(':checked')) {
+            ip_payment_comparison_enabled.prop("checked", false);
+            $('.sqrip-tab[data-tab="comparison"]').hide();
+        }
     }
 
     tab_active = window.location.hash.slice(1);

--- a/sqrip-woocommerce.php
+++ b/sqrip-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name:             sqrip.ch
  * Plugin URI:              https://sqrip.ch/
  * Description:             sqrip – A comprehensive, flexible and clever WooCommerce finance tool for the most widely used payment method in Switzerland: the bank transfers.
- * Version:                 1.10.1
+ * Version:                 1.10.2
  * Author:                  netmex digital gmbh
  * Author URI:              https://sqrip.ch/
  * Text Domain:             sqrip-swiss-qr-invoice
@@ -245,10 +245,10 @@ function sqrip_add_admin_notice()
 
 add_action('admin_enqueue_scripts', function ($hook_suffix) {
 
-    wp_enqueue_style('sqrip-admin', plugins_url('css/sqrip-admin.css', __FILE__), '', '1.10.1');
+    wp_enqueue_style('sqrip-admin', plugins_url('css/sqrip-admin.css', __FILE__), '', '1.10.2');
 
     if (isset($_GET['section']) && $_GET['section'] == "sqrip") {
-        wp_enqueue_script('sqrip-admin', plugins_url('js/sqrip-admin.js', __FILE__), array('jquery', 'selectWoo'), '1.10.1', true);
+        wp_enqueue_script('sqrip-admin', plugins_url('js/sqrip-admin.js', __FILE__), array('jquery', 'selectWoo'), '1.10.2', true);
 
         $sqrip_new_status = sqrip_get_plugin_option('enabled_new_status');
         $sqrip_new_awaiting_status = sqrip_get_plugin_option('enabled_new_awstatus');
@@ -316,8 +316,8 @@ add_action('admin_enqueue_scripts', function ($hook_suffix) {
         $screen->id === $sqrip_hpos_order_screen
     )) {
 
-        wp_enqueue_script('sqrip-order', plugins_url('js/sqrip-order.js', __FILE__), array('jquery'), '1.10.1', true);
-        wp_enqueue_script('sqrip-refund', plugins_url('js/sqrip-refund.js', __FILE__), array('jquery'), '1.10.1', true);
+        wp_enqueue_script('sqrip-order', plugins_url('js/sqrip-order.js', __FILE__), array('jquery'), '1.10.2', true);
+        wp_enqueue_script('sqrip-refund', plugins_url('js/sqrip-refund.js', __FILE__), array('jquery'), '1.10.2', true);
 
         wp_localize_script('sqrip-order', 'sqrip',
             array(
@@ -332,7 +332,7 @@ add_action('admin_enqueue_scripts', function ($hook_suffix) {
     }
 
     if (in_array($hook_suffix, ['user-edit.php', 'profile.php'])) {
-        wp_enqueue_script('sqrip-customer-profile', plugins_url('js/sqrip-customer-profile.js', __FILE__), array('jquery'), '1.10.1', true);
+        wp_enqueue_script('sqrip-customer-profile', plugins_url('js/sqrip-customer-profile.js', __FILE__), array('jquery'), '1.10.2', true);
         wp_localize_script('sqrip-customer-profile', 'sqrip', array('ajax_url' => admin_url('admin-ajax.php')));
     }
 
@@ -352,9 +352,9 @@ function sqrip_enqueue_scripts()
     // The third argument is $deps, so the version was left at false and WordPress
     // appended its own core version — which does not change when the plugin ships new
     // CSS. Returning visitors then combined new JS with a cached stylesheet.
-    wp_enqueue_style('sqrip', plugins_url('css/sqrip-order.css', __FILE__), array(), '1.10.1');
+    wp_enqueue_style('sqrip', plugins_url('css/sqrip-order.css', __FILE__), array(), '1.10.2');
 
-    wp_enqueue_script('sqrip', plugins_url('js/sqrip-fe.js', __FILE__), array('jquery'), '1.10.1', true);
+    wp_enqueue_script('sqrip', plugins_url('js/sqrip-fe.js', __FILE__), array('jquery'), '1.10.2', true);
 
     wp_localize_script('sqrip', 'sqrip',
         array(


### PR DESCRIPTION
## What this fixes

`toggleComparisonAndMultipleSlips()` in `js/sqrip-admin.js` switched checkboxes the merchant never touched, in three ways:

1. **Called on page load with no argument.** It falls into the branch meant for the multiple-QR-slips checkbox and ticks *Payment Comparison* on every shop that has multiple slips off — regardless of the stored setting, which defaults to `no`. Saving anything on that screen then wrote `payment_comparison_enabled = yes` and reported the service as active to the sqrip account.
2. **Both `else` branches ticked the *other* checkbox when one was unticked.** Switching Payment Comparison off switched Multiple QR-Slips on, and the other way round. Both features off was impossible.
3. **The outer `else` caught every other feature**, so toggling the Refunds checkbox ran the multiple-QR-slips branch too.

Introduced in 1.10. V1.8.4 has no such function at all.

## What changed

The exclusion is now one-directional and scoped to the two features it concerns: switching one **on** switches the other **off**; switching one **off** leaves it alone.

Nothing else about the settings screen changes — including hiding the Payment Comparison tab while the feature is off, which is the behaviour that shipped for years.

Asset version stamps go to 1.10.2 as well, otherwise browsers keep serving the cached `sqrip-admin.js` and the fix never reaches the merchant.

## Verified

- Tested by the maintainer against a live shop
- PHP 8.5 lint clean, JS syntax clean
- No PHP, gateway or translation files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)