### PR TITLE
1.10.3: QR slip in the PDF invoice for manual orders, building number in the payee address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 .DS_Store
 .idea
+
+# Real bank statements used while testing the camt reconciliation. Never commit
+# these: one file holds a shop's entire month of banking — IBANs, and the names
+# and addresses of every payer. Deliberately narrow, so the synthetic fixtures
+# under tests/camt/fixtures/ stay tracked.
+CAMT/

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://sqrip.ch/
 Tags: woocommerce, payment, swiss qr invoice, qr-rechnung, einzahlungsschein
 Requires at least: 6.0
 Tested up to: 7.0
-Stable tag: 1.10.2
+Stable tag: 1.10.3
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -145,6 +145,9 @@ Yes. We are already working on comparing the reconciliation of orders/purchases 
 7. Refund functionality
 
 == Changelog ==
+= 1.10.3 : Juli 2026 – Fix =
+* Orders you enter by hand in the backend now get the QR slip inside the PDF invoice as well, if you use the 'PDF Invoices & Packing Slips' integration. Until now only orders placed through the shop did, so the same order taken by phone or e-mail produced an invoice without the QR slip;
+
 = 1.10.2 : Juli 2026 – Fix =
 * Opening the sqrip settings no longer ticks 'Payment Comparison' by itself. On shops with the feature switched off the checkbox appeared ticked as soon as the settings screen was opened, so saving switched the feature on. It affects 1.10 and 1.10.1; if you do not use the payment comparison, check the setting once on the Services tab after updating;
 * Switching 'Payment Comparison' off no longer switches 'Multiple QR-Slips' on, and the other way round. The two still cannot run at the same time — switching one on turns the other off — but you can now leave both off, which was impossible before. Toggling the Refunds checkbox no longer affected the two either;
@@ -349,6 +352,9 @@ We made users (even more) happy with these changes:
 * Here we go!
 
 == Upgrade Notice ==
+= 1.10.3 =
+For shops that combine the QR slip with the invoice of 'PDF Invoices & Packing Slips': orders entered by hand in the backend now get the QR slip in the invoice too, just like orders placed through the shop. No settings change.
+
 = 1.10.2 =
 Recommended update for everyone on 1.10 or 1.10.1: opening the sqrip settings ticked 'Payment Comparison' by itself, so saving switched the feature on. If you do not use it, check that setting once on the Services tab after updating.
 

--- a/README.txt
+++ b/README.txt
@@ -145,8 +145,9 @@ Yes. We are already working on comparing the reconciliation of orders/purchases 
 7. Refund functionality
 
 == Changelog ==
-= 1.10.3 : Juli 2026 – Fix =
+= 1.10.3 : Juli 2026 – Fixes =
 * Orders you enter by hand in the backend now get the QR slip inside the PDF invoice as well, if you use the 'PDF Invoices & Packing Slips' integration. Until now only orders placed through the shop did, so the same order taken by phone or e-mail produced an invoice without the QR slip;
+* The payee address now shows the building number when the address is taken from your sqrip account. The number is stored in your account and delivered by the sqrip API, but the plugin left it out of the QR bill — so the payee address was printed incomplete, which the structured addresses require it not to be. The other two address sources, and the payer address, were never affected;
 
 = 1.10.2 : Juli 2026 – Fix =
 * Opening the sqrip settings no longer ticks 'Payment Comparison' by itself. On shops with the feature switched off the checkbox appeared ticked as soon as the settings screen was opened, so saving switched the feature on. It affects 1.10 and 1.10.1; if you do not use the payment comparison, check the setting once on the Services tab after updating;

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -447,6 +447,12 @@ function sqrip_get_user_details($token = "", $return = "address")
                 'name' => $name,
                 'postal_code' => $address->zip,
                 'street' => $address->street,
+                // The sqrip account keeps street and building number apart, exactly as the
+                // structured addresses require, and GET /details returns both. This branch
+                // used to drop the number, so shops set to "from the sqrip account" printed
+                // a payee address without it — while the other two address sources, and the
+                // payer address, have always passed it on.
+                'building_number' => isset($address->building_number) ? $address->building_number : "",
             );
         }
 

--- a/sqrip-woocommerce.php
+++ b/sqrip-woocommerce.php
@@ -4,7 +4,7 @@
  * Plugin Name:             sqrip.ch
  * Plugin URI:              https://sqrip.ch/
  * Description:             sqrip – A comprehensive, flexible and clever WooCommerce finance tool for the most widely used payment method in Switzerland: the bank transfers.
- * Version:                 1.10.2
+ * Version:                 1.10.3
  * Author:                  netmex digital gmbh
  * Author URI:              https://sqrip.ch/
  * Text Domain:             sqrip-swiss-qr-invoice
@@ -245,10 +245,10 @@ function sqrip_add_admin_notice()
 
 add_action('admin_enqueue_scripts', function ($hook_suffix) {
 
-    wp_enqueue_style('sqrip-admin', plugins_url('css/sqrip-admin.css', __FILE__), '', '1.10.2');
+    wp_enqueue_style('sqrip-admin', plugins_url('css/sqrip-admin.css', __FILE__), '', '1.10.3');
 
     if (isset($_GET['section']) && $_GET['section'] == "sqrip") {
-        wp_enqueue_script('sqrip-admin', plugins_url('js/sqrip-admin.js', __FILE__), array('jquery', 'selectWoo'), '1.10.2', true);
+        wp_enqueue_script('sqrip-admin', plugins_url('js/sqrip-admin.js', __FILE__), array('jquery', 'selectWoo'), '1.10.3', true);
 
         $sqrip_new_status = sqrip_get_plugin_option('enabled_new_status');
         $sqrip_new_awaiting_status = sqrip_get_plugin_option('enabled_new_awstatus');
@@ -316,8 +316,8 @@ add_action('admin_enqueue_scripts', function ($hook_suffix) {
         $screen->id === $sqrip_hpos_order_screen
     )) {
 
-        wp_enqueue_script('sqrip-order', plugins_url('js/sqrip-order.js', __FILE__), array('jquery'), '1.10.2', true);
-        wp_enqueue_script('sqrip-refund', plugins_url('js/sqrip-refund.js', __FILE__), array('jquery'), '1.10.2', true);
+        wp_enqueue_script('sqrip-order', plugins_url('js/sqrip-order.js', __FILE__), array('jquery'), '1.10.3', true);
+        wp_enqueue_script('sqrip-refund', plugins_url('js/sqrip-refund.js', __FILE__), array('jquery'), '1.10.3', true);
 
         wp_localize_script('sqrip-order', 'sqrip',
             array(
@@ -332,7 +332,7 @@ add_action('admin_enqueue_scripts', function ($hook_suffix) {
     }
 
     if (in_array($hook_suffix, ['user-edit.php', 'profile.php'])) {
-        wp_enqueue_script('sqrip-customer-profile', plugins_url('js/sqrip-customer-profile.js', __FILE__), array('jquery'), '1.10.2', true);
+        wp_enqueue_script('sqrip-customer-profile', plugins_url('js/sqrip-customer-profile.js', __FILE__), array('jquery'), '1.10.3', true);
         wp_localize_script('sqrip-customer-profile', 'sqrip', array('ajax_url' => admin_url('admin-ajax.php')));
     }
 
@@ -352,9 +352,9 @@ function sqrip_enqueue_scripts()
     // The third argument is $deps, so the version was left at false and WordPress
     // appended its own core version — which does not change when the plugin ships new
     // CSS. Returning visitors then combined new JS with a cached stylesheet.
-    wp_enqueue_style('sqrip', plugins_url('css/sqrip-order.css', __FILE__), array(), '1.10.2');
+    wp_enqueue_style('sqrip', plugins_url('css/sqrip-order.css', __FILE__), array(), '1.10.3');
 
-    wp_enqueue_script('sqrip', plugins_url('js/sqrip-fe.js', __FILE__), array('jquery'), '1.10.2', true);
+    wp_enqueue_script('sqrip', plugins_url('js/sqrip-fe.js', __FILE__), array('jquery'), '1.10.3', true);
 
     wp_localize_script('sqrip', 'sqrip',
         array(

--- a/sqrip-woocommerce.php
+++ b/sqrip-woocommerce.php
@@ -964,12 +964,22 @@ add_action('woocommerce_process_shop_order_meta', function($post_id) {
                     $order->update_meta_data('sqrip_qr_pdf_attachment_id', $sqrip_qr_pdf_attachment_id);
                     $order->update_meta_data('sqrip_pdf_file_url', $sqrip_qr_pdf_url);
                     $order->update_meta_data('sqrip_pdf_file_path', $sqrip_qr_pdf_path);
+
+                    // The image the "PDF Invoices & Packing Slips" integration embeds into
+                    // the invoice. Both checkout paths store it — the gateway's
+                    // process_payment() and process_payment_stt() in inc/functions.php —
+                    // but this third copy of the QR generation never did. So an order taken
+                    // by phone or e-mail and entered by hand produced an invoice without the
+                    // QR slip, while the identical order placed through the shop produced
+                    // one with it.
+                    if (sqrip_get_plugin_option('pdf_invoice_integration') === 'yes'
+                        && isset($response_body->png_file)
+                    ) {
+                        $order->update_meta_data('sqrip_png_file_url', $response_body->png_file);
+                    }
                 }
 
                 $order->update_meta_data('sqrip_refund_iban_num', get_user_meta($order->get_user_id(), 'iban_num', true));
-
-                // $order->update_meta_data('sqrip_png_file_url', $sqrip_qr_png_url);
-                // $order->update_meta_data('sqrip_png_file_path', $sqrip_qr_png_path);
 
                 $order->save();
 


### PR DESCRIPTION
Two customer-reported defects, both verified against production data before changing anything.

## 1. Manually created orders got no QR slip in the PDF invoice

`wpo_wcpdf_tax_exempt()` embeds `sqrip_png_file_url` into the "PDF Invoices & Packing Slips" document and renders nothing when that meta is empty. Two of the three copies of the QR generation store it — the gateway's `process_payment()` and `process_payment_stt()` — while the third, the `woocommerce_process_shop_order_meta` handler behind the backend button, had the two lines commented out since the feature was added.

Checked on a live shop: **all 3** orders with `created_via = 'admin'` lack the meta, **36 of 37** checkout orders have it. The single exception is a multi-slip order — a separate gap, tracked as SRS-51 for 1.11 and deliberately left alone here.

## 2. Payee address from the sqrip account had no building number

Reported by a customer with the address setting on "from the sqrip account" and the number correctly filled in on the server.

Verified against `GET /api/details`: the account keeps the two apart and returns both (`"street": "Loomattenweg"`, `"building_number": "19"`). `sqrip_get_user_details()` assembled the address from five fields and dropped the number, so it never reached the request.

The other two payee sources and the payer address have always passed it on. This branch was the only gap — and the one that matters for the structured addresses in force since 22 November 2025, where an address without the building number is incomplete.

## Also

`CAMT/` is now git-ignored: the folder of real bank statements kept for testing the reconciliation. One such file holds a whole month of a shop's banking, and this repository is public. The synthetic fixtures under `tests/camt/fixtures/` stay tracked.

## Verified

- PHP 8.5 lint clean on every changed file
- Built package checked: version 1.10.3, both fixes present, no bank data
- No settings change for any shop

🤖 Generated with [Claude Code](https://claude.com/claude-code)